### PR TITLE
bugfix for detecting missing MetaData

### DIFF
--- a/nixpkgs-review-checks-hook
+++ b/nixpkgs-review-checks-hook
@@ -38,8 +38,8 @@ _nixpkgs-review-checks-hook() {
         package="${package_log_file%.*}"
         lint_check_package=../lint_checks.$package.tmp
 
-        missingMeta="$(nix-instantiate --eval -E "(import ../nixpkgs/ { }).pkgs.$package.meta.description" || true)"
-        if [[ -n $missingMeta ]]; then
+        missingMeta="$(nix-instantiate --eval -E "(import ../nixpkgs { }).pkgs.$package.meta.description" || true)"
+        if [[ -z $missingMeta ]]; then
           cat <<EOF >>"$lint_check_package"
 Package is missing a meta section.
 If the package is using runCommand please make sure to inherit or create a meta section.


### PR DESCRIPTION
MissingMeta isn't correctly detected. This fixes the check for the string length.