### PR TITLE
Fix false-positive missing meta

### DIFF
--- a/nixpkgs-review-checks-hook
+++ b/nixpkgs-review-checks-hook
@@ -38,13 +38,23 @@ _nixpkgs-review-checks-hook() {
         package="${package_log_file%.*}"
         lint_check_package=../lint_checks.$package.tmp
 
-        missingMeta="$(nix-instantiate --eval -E "(import ../nixpkgs { }).pkgs.$package.meta.description" || true)"
+        missingMeta="$(nix-instantiate --eval -E "(import ../nixpkgs { }).pkgs.$package.meta" || true)"
         if [[ -z $missingMeta ]]; then
           cat <<EOF >>"$lint_check_package"
 Package is missing a meta section.
 If the package is using runCommand please make sure to inherit or create a meta section.
 
 EOF
+        else
+          # Get the first one to ensure the list is not empty
+          missingMaintainers="$(nix-instantiate --eval -E "builtins.head (import ../nixpkgs { }).pkgs.$package.meta.maintainers" || true)"
+          if [[ -z $missingMaintainers ]]; then
+            cat <<EOF >>"$lint_check_package"
+Package is missing maintainers.
+If the package is using runCommand please make sure to inherit or list one or more maintainers.
+
+EOF
+          fi
         fi
 
         package_nix_file="$(cd ../nixpkgs && EDITOR="echo" nix edit -f . "$package" 2>/dev/null || echo skip)"


### PR DESCRIPTION
As seen in https://github.com/NixOS/nixpkgs/pull/209591#issuecomment-1374764471 (and the following comment), a false positive is reported on (some) `nixosTets`, about a missing `meta` section even when the test does in fact have `meta.maintainers`.

I strongly assume this to be caused by checking for `meta.description` instead of `meta` more generally: https://github.com/SuperSandro2000/nixpkgs-review-checks/blob/13ea8bcf9e62d99530f7bbad0852315dba408f0f/nixpkgs-review-checks-hook#L41-L48

This PR addresses this by generally checking for meta itself instead of meta.description. Additionally, a check for meta.maintainers has been added to ensure the meta attrset is actually populated.