### PR TITLE
fix package names in log folder

### DIFF
--- a/nixpkgs-review-checks-hook
+++ b/nixpkgs-review-checks-hook
@@ -35,8 +35,7 @@ _nixpkgs-review-checks-hook() {
       # run commands for each package build
       cd logs/ 2>/dev/null || exit
       for package_log_file in *.log; do
-        SYSTEMS="x86_64-linux|aarch64-linux|x86_64-darwin|aarch64-darwin"
-        package=$(echo $package_log_file | sed -nE "s/(.*?)-(${SYSTEMS}).log/\1/p")
+        package=$(echo $package_log_file | sed -nE "s/(.*?)-(x86_64-linux|aarch64-linux|x86_64-darwin|aarch64-darwin).log/\1/p")
         lint_check_package=../lint_checks.$package.tmp
 
         missingMeta="$(nix-instantiate --eval -E "(import ../nixpkgs { }).pkgs.$package.meta" || true)"

--- a/nixpkgs-review-checks-hook
+++ b/nixpkgs-review-checks-hook
@@ -35,7 +35,8 @@ _nixpkgs-review-checks-hook() {
       # run commands for each package build
       cd logs/ 2>/dev/null || exit
       for package_log_file in *.log; do
-        package="${package_log_file%.*}"
+        SYSTEMS="x86_64-linux|aarch64-linux|x86_64-darwin|aarch64-darwin"
+        package=$(echo $package_log_file | sed -nE "s/(.*?)-(${SYSTEMS}).log/\1/p")
         lint_check_package=../lint_checks.$package.tmp
 
         missingMeta="$(nix-instantiate --eval -E "(import ../nixpkgs { }).pkgs.$package.meta" || true)"


### PR DESCRIPTION
In the newer nixpkgs-review version the log now names the package like PACKAGE-SYSTEM.log which will cause errors like

```
Package is missing a meta section. If the package is using runCommand
please make sure to inherit or create a
meta section.

error: AttrPathNotFound Packages in
‘/nix/store/vx1psq29l9rhlvq01rf67wnx2avk0z6d-nixpkgs’ do not contain
‘k9s-x86_64’ attribute.
```

this commit now uses regex to filter the most common system names (as defined by nixpkgs-review upstream[1])

[1]: https://github.com/Mic92/nixpkgs-review?tab=readme-ov-file#review-changes-for-other-operating-systemsarchitectures